### PR TITLE
✨ 放送作成機能の実装

### DIFF
--- a/src/hooks/postBroadcast.ts
+++ b/src/hooks/postBroadcast.ts
@@ -9,8 +9,5 @@ export const postBroadcast = (url: string, body: any, token: string) => {
       "Content-Type": "application/json",
     },
     body: JSON.stringify({ ...body }),
-  }).then((res) => {
-    if (res.status >= 400) throw new Error(`${res.status}`);
-    return res.status;
-  });
+  }).then((res) => res.status);
 };

--- a/src/hooks/postBroadcast.ts
+++ b/src/hooks/postBroadcast.ts
@@ -1,0 +1,16 @@
+import { API_URL } from "src/constants/API_URL";
+import fetch from "unfetch";
+
+export const postBroadcast = (url: string, body: any, token: string) => {
+  return fetch(`${API_URL}${url}`, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ ...body }),
+  }).then((res) => {
+    if (res.status >= 400) throw new Error(`${res.status}`);
+    return res.status;
+  });
+};

--- a/src/pages/broadcast/input.page.tsx
+++ b/src/pages/broadcast/input.page.tsx
@@ -15,23 +15,23 @@ const BroadcastInputPage: NextPage = () => {
   const [broadcastState, setBroadcastState] = useState<BroadcastPostBodyType>({
     title: "",
     scheduledStartTime: "",
-	});
-	const [buttonDisabledState, setButtonDisabledState] = useState(false);
+  });
+  const [buttonDisabledState, setButtonDisabledState] = useState(false);
 
-	const handleSaveClick = async () => {
-		// 連続クリックで重複して送信しないようにする
-		setButtonDisabledState(true);
-		const toastId = toast.loading("Sending...");
-		const statusCode = await postBroadcast("/broadcast", broadcastState, userInfo.token);
-		if (statusCode >= 400) {
-			toast.error(`error: ${statusCode}`, { id: toastId });
-			setButtonDisabledState(false);
-		} else {
-			toast.success("保存成功しました", { id: toastId });
-			// トーストを表示した2秒後にページ遷移する
-			setTimeout(() => router.push("/broadcast"), 2000);
-		}
-	};
+  const handleSaveClick = async () => {
+    // 連続クリックで重複して送信しないようにする
+    setButtonDisabledState(true);
+    const toastId = toast.loading("Sending...");
+    const statusCode = await postBroadcast("/broadcast", broadcastState, userInfo.token);
+    if (statusCode >= 400) {
+      toast.error(`error: ${statusCode}`, { id: toastId });
+      setButtonDisabledState(false);
+    } else {
+      toast.success("保存成功しました", { id: toastId });
+      // トーストを表示した2秒後にページ遷移する
+      setTimeout(() => router.push("/broadcast"), 2000);
+    }
+  };
 
   return (
     <PageRoot>

--- a/src/pages/broadcast/input.page.tsx
+++ b/src/pages/broadcast/input.page.tsx
@@ -19,6 +19,10 @@ const BroadcastInputPage: NextPage = () => {
   const [buttonDisabledState, setButtonDisabledState] = useState(false);
 
   const handleSaveClick = async () => {
+    if (!broadcastState.title || !broadcastState.scheduledStartTime) {
+      toast.error("タイトルと放送日を指定してください");
+      return;
+    }
     // 連続クリックで重複して送信しないようにする
     setButtonDisabledState(true);
     const toastId = toast.loading("Sending...");

--- a/src/pages/broadcast/input.page.tsx
+++ b/src/pages/broadcast/input.page.tsx
@@ -19,7 +19,8 @@ const BroadcastInputPage: NextPage = () => {
   const [buttonDisabledState, setButtonDisabledState] = useState(false);
 
   const handleSaveClick = async () => {
-    if (!broadcastState.title || !broadcastState.scheduledStartTime) {
+    // タイトル、放送日を指定しないと作成できないようにする。空白文字列も作成できない。
+    if (!broadcastState.title || !broadcastState.scheduledStartTime || /\S/g.test(broadcastState.title)) {
       toast.error("タイトルと放送日を指定してください");
       return;
     }

--- a/src/pages/broadcast/input.page.tsx
+++ b/src/pages/broadcast/input.page.tsx
@@ -1,17 +1,62 @@
 import type { NextPage } from "next";
+import { useState } from "react";
+import { useRouter } from "next/router";
 import { Button, Input, PageRoot, Title } from "src/components/styled";
 import { styled } from "src/utils";
+import toast, { Toaster } from "react-hot-toast";
+import { postBroadcast } from "src/hooks/postBroadcast";
+import { BroadcastPostBodyType } from "src/types/BroadcastPostBodyType";
+import { useRecoilValue } from "recoil";
+import { userInfoState } from "src/components/atoms";
 
 const BroadcastInputPage: NextPage = () => {
+  const userInfo = useRecoilValue(userInfoState);
+  const router = useRouter();
+  const [broadcastState, setBroadcastState] = useState<BroadcastPostBodyType>({
+    title: "",
+    scheduledStartTime: "",
+	});
+	const [buttonDisabledState, setButtonDisabledState] = useState(false);
+
+	const handleSaveClick = async () => {
+		// 連続クリックで重複して送信しないようにする
+		setButtonDisabledState(true);
+		const toastId = toast.loading("Sending...");
+		const statusCode = await postBroadcast("/broadcast", broadcastState, userInfo.token);
+		if (statusCode >= 400) {
+			toast.error(`error: ${statusCode}`, { id: toastId });
+			setButtonDisabledState(false);
+		} else {
+			toast.success("保存成功しました", { id: toastId });
+			// トーストを表示した2秒後にページ遷移する
+			setTimeout(() => router.push("/broadcast"), 2000);
+		}
+	};
+
   return (
     <PageRoot>
       <Title>放送を作成</Title>
-      <Input type="text" placeholder="タイトルを入力する" />
-      <Input type="date" placeholder="2021/09/03" />
+      <Input
+        type="text"
+        placeholder="タイトルを入力する"
+        onChange={(e) => setBroadcastState({ ...broadcastState, title: e.target.value })}
+      />
+      <Input
+        type="date"
+        placeholder="2021/09/03"
+        onChange={(e) =>
+          setBroadcastState({ ...broadcastState, scheduledStartTime: `${e.target.value}T00:00:00+09:00` })
+        }
+      />
       <ButtonWrap>
-        <Button color="primary">保存する</Button>
-        <Button color="secondary">キャンセル</Button>
+        <Button color="primary" disabled={buttonDisabledState} onClick={handleSaveClick}>
+          保存する
+        </Button>
+        <Button color="secondary" disabled={buttonDisabledState} onClick={() => router.push("/broadcast")}>
+          キャンセル
+        </Button>
       </ButtonWrap>
+      <Toaster />
     </PageRoot>
   );
 };

--- a/src/pages/broadcast/input.page.tsx
+++ b/src/pages/broadcast/input.page.tsx
@@ -20,7 +20,7 @@ const BroadcastInputPage: NextPage = () => {
 
   const handleSaveClick = async () => {
     // タイトル、放送日を指定しないと作成できないようにする。空白文字列も作成できない。
-    if (!broadcastState.title || !broadcastState.scheduledStartTime || /\S/g.test(broadcastState.title)) {
+    if (!broadcastState.title || !broadcastState.scheduledStartTime || !/\S/g.test(broadcastState.title)) {
       toast.error("タイトルと放送日を指定してください");
       return;
     }
@@ -37,6 +37,7 @@ const BroadcastInputPage: NextPage = () => {
       setTimeout(() => router.push("/broadcast"), 2000);
     }
   };
+  console.log(`test: ${/\S/g.test(broadcastState.title)}`);
 
   return (
     <PageRoot>

--- a/src/types/BroadcastPostBodyType.ts
+++ b/src/types/BroadcastPostBodyType.ts
@@ -1,0 +1,4 @@
+export type BroadcastPostBodyType = {
+  title: string;
+  scheduledStartTime: string;
+};


### PR DESCRIPTION
## 変更内容

- APIにリクエストを送って放送を作成できるようにした。
- リクエスト結果によってトーストの表示結果を変えるようにした。
- 放送の作成が成功したあと、放送一覧ページにリダイレクトするようにした。
- キャンセルボタンを押すと、放送一覧ページに遷移するようにした。
- ボタンを連続クリックして放送が重複登録されないように、ボタンを無効化する処理を実装した。

## 確認して欲しい項目

- [x] 放送が新しくDBに作成されているか
- [x] 放送のタイトルと放送日を指定して、`保存する`ボタンを押したあと、トーストで成功メッセージが表示されているか
- [x] 放送のタイトルか放送日どちらかを指定せずに`保存する`ボタンを押すと、トーストでエラーが表示されているか
- [x] `保存する`ボタンを連続クリックしても、放送が重複して保存されないか
- [x] `キャンセル`ボタンを押すと、放送一覧ページに遷移するか

## どうやって確認するのか（必須）

1. 最新の engivia-fastifyのレポジトリをローカルにpullする。
2. `http://localhost:3000/broadcast/input` にアクセス。
3. タイトルと放送日を入力して動作するか確認する。

## 新たな課題

- フロント側で入力値のチェックをしていないので、タイトルや放送日を入力していなくてもAPIにリクエストを送ることができてしまう。フロント側でも入力値のチェックを実装してもいいかも。

Closes #45
