### PR TITLE
Slack認証の実装

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -9,7 +9,7 @@ type Props = {
 
 export const Layout: VFC<Props> = (props) => {
   const router = useRouter();
-  const notSignin = router.pathname !== "/signin";
+  const notSignin = router.pathname !== "/signin" && router.pathname !== "/signin/oauth_redirect";
 
   return (
     <Root>

--- a/src/pages/signin/index.page.tsx
+++ b/src/pages/signin/index.page.tsx
@@ -3,6 +3,7 @@ import type { NextPage } from "next";
 import Image from "next/image";
 import { Button } from "src/components/styled";
 import { styled } from "src/utils";
+import { API_URL } from "src/constants/API_URL";
 
 const SigninPage: NextPage = () => {
   return (
@@ -12,10 +13,12 @@ const SigninPage: NextPage = () => {
         <Title>エンジビアの泉</Title>
         <SubTitle>〜素晴らしきプログラミングマメ知識〜</SubTitle>
         <Spacer />
-        <Button color="white">
-          <Image src="/slack-logo.svg" alt="slackのアイコン" width={22} height={22} />
-          Sign in with Slack
-        </Button>
+        <a href={`${API_URL}/slack/signin`}>
+          <Button color="white">
+            <Image src="/slack-logo.svg" alt="slackのアイコン" width={22} height={22} />
+            Sign in with Slack
+          </Button>
+        </a>
       </LeftSide>
 
       <RightSide>

--- a/src/pages/signin/oauth_redirect.page.tsx
+++ b/src/pages/signin/oauth_redirect.page.tsx
@@ -29,7 +29,7 @@ const signinRedirectPage: NextPage = () => {
   const setUserInfoState = useSetRecoilState(userInfoState);
   // Slack認証をしてユーザー情報を取得する
   const { data, error } = useSWR<User>(`${API_URL}/slack/token?code=${router.query.code}`, fetcher);
-  if (data) {
+  if (data && !error) {
     setUserInfoState(data);
     router.push("/broadcast");
   }

--- a/src/pages/signin/oauth_redirect.page.tsx
+++ b/src/pages/signin/oauth_redirect.page.tsx
@@ -1,0 +1,46 @@
+import type { NextPage } from "next";
+import { PageRoot } from "src/components/styled";
+import { useRouter } from "next/router";
+import { styled } from "src/utils";
+import useSWR from "swr";
+import { API_URL } from "src/constants/API_URL";
+import fetch from "unfetch";
+import { useSetRecoilState } from "recoil";
+import { userInfoState } from "src/components/atoms";
+
+type User = {
+  id: string;
+  name: string;
+  isAdmin: boolean;
+  image: string;
+  token: string;
+};
+
+const fetcher = async (url: string) => {
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error("slack oauth error");
+  }
+  return res.json();
+};
+
+const signinRedirectPage: NextPage = () => {
+  const router = useRouter();
+  const setUserInfoState = useSetRecoilState(userInfoState);
+  // Slack認証をしてユーザー情報を取得する
+  const { data, error } = useSWR<User>(`${API_URL}/slack/token?code=${router.query.code}`, fetcher);
+  if (data) {
+    setUserInfoState(data);
+    router.push("/broadcast");
+  }
+  return <PageRoot>{error ? <H1>認証エラー</H1> : data ? null : <H1>認証中</H1>}</PageRoot>;
+};
+
+// eslint-disable-next-line import/no-default-export
+export default signinRedirectPage;
+
+const H1 = styled("h1", {
+  paddingTop: "5rem",
+  fontSize: "2rem",
+  fontWeight: "bold",
+});


### PR DESCRIPTION
## 変更内容

- サインインページでボタンをクリックしてSlack認証ができるようにした。
- Slack認証で取得したデータをRecoilで管理するようにした。

## 確認して欲しい項目

- [ ] Slack認証が成功した後、DBのユーザーテーブルに新しくユーザーが追加されているか確認する。

## どうやって確認するのか

1. サインページで`Sign in with Slack`ボタンを押す。
2. 権限リクエスト画面で`許可する`ボタンを押す。
3. (例)`https://hoo-hoge.ngrok.io/signin/oauth_redirect?code=123...`にリダイレクトされる。
4. クエリパラメーターをコピーする。(code=`123...`の部分)
5. コピーしたのを`http://localhost:3000/signin/oauth_redirect?code=123...`のようにして貼り付ける。
6. 認証に成功すると放送一覧ページにリダイレクトされる。（DBにもユーザー情報が保存される。）

## 備考

- 確認する際、engivia-fastifyの最新のdevelopブランチをプルしてください。
-

Closes #71