### PR TITLE
SWRで取得したデータが更新されないバグを修正

### DIFF
--- a/src/hooks/useGetEngiviaInfo.ts
+++ b/src/hooks/useGetEngiviaInfo.ts
@@ -1,15 +1,16 @@
 import { useEffect } from "react";
 import { useSetRecoilState } from "recoil";
+import { broadcastLiveState } from "src/components/atoms";
 import { API_URL } from "src/constants/API_URL";
 import type { BroadcastLiveType } from "src/types";
-import useSWRImmutable from "swr/immutable";
+import useSWR from "swr";
 import fetch from "unfetch";
-import { broadcastLiveState } from "src/components/atoms";
 
 const fetchWithToken = (url: string, token: string) => {
   return fetch(url, {
     method: "GET",
     headers: {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       Authorization: `Bearer ${token}`,
     },
   }).then((res) => res.json());
@@ -18,7 +19,9 @@ const fetchWithToken = (url: string, token: string) => {
 export const useGetEngiviaInfo = (url: string, token: string) => {
   const setBroadcast = useSetRecoilState(broadcastLiveState);
 
-  const { data, error } = useSWRImmutable<BroadcastLiveType>([`${API_URL}${url}`, token], fetchWithToken);
+  const { data, error } = useSWR<BroadcastLiveType>([`${API_URL}${url}`, token], fetchWithToken, {
+    revalidateOnFocus: false,
+  });
 
   useEffect(() => {
     console.info(data);
@@ -29,6 +32,7 @@ export const useGetEngiviaInfo = (url: string, token: string) => {
           engiviaNumber: index + 1,
         };
       });
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       setBroadcast({ ...data, Trivia: numberAddTriviaList });
     }
   }, [data]);

--- a/src/hooks/useGetSWR.ts
+++ b/src/hooks/useGetSWR.ts
@@ -1,8 +1,8 @@
-import useSWRImmutable from "swr/immutable";
 import { getFetcher } from "src/functions/getFetcher";
+import useSWR from "swr";
 
 export const useGetSWR = <T extends unknown>(url: string) => {
-  const { data, error } = useSWRImmutable<T>(url, getFetcher);
+  const { data, error } = useSWR<T>(url, getFetcher, { revalidateOnFocus: false });
 
   return {
     data: data,
@@ -12,7 +12,7 @@ export const useGetSWR = <T extends unknown>(url: string) => {
 };
 
 export const useGetSWRWithToken = <T extends unknown>(url: string, token: string) => {
-  const { data, error } = useSWRImmutable<T>([url, token]);
+  const { data, error } = useSWR<T>([url, token], { revalidateOnFocus: false });
 
   return {
     data: data,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -32,5 +32,7 @@ export type BroadcastListType = {
   title: string;
   scheduledStartTime: string;
   status: LiveStatus;
-  count: number;
+  _count: {
+    Trivia: number;
+  }
 };


### PR DESCRIPTION
## 変更内容（必須）

- useSWRImmutableを廃止して、useSWRを使うようにした。
- ウィンドウがフォーカスされたときに自動的に再検証`revalidateOnFocus`を無効化した。

## 確認して欲しい項目（必須）

- [ ] エンジビア投稿した後、放送一覧のエンジビア数が更新されているか
- [ ] エンジビア投稿した後、放送一覧から投稿した放送をクリックして、画面遷移先が編集画面になっているか

## どうやって確認するのか（必須）

1. 必要に応じでnpx prisma migrate resetを実行。
2. 「第3回エンジビアの泉」にエンジビアを投稿する。
3. 放送一覧に画面遷移した後、「第3回エンジビアの泉」のエンジビア数が2から3になっていることを確認する。
4. 放送一覧から「第3回エンジビアの泉」をクリックして、画面遷移した後、編集画面が表示されていることを確認する。

## 新たな課題

- なし