### PR TITLE
🐛 エンジビアカードにユーザーアイコンが表示されていない  #93

### DIFF
--- a/src/components/EngiviaCard.tsx
+++ b/src/components/EngiviaCard.tsx
@@ -22,7 +22,7 @@ export const EngiviaCard: VFC<Props> = (props) => {
           <EngiviaContent>{props.content}</EngiviaContent>
           <Content>
             <UserInfoWrap>
-              <Icon />
+              <Icon>{props.image ? <Image src={props.image} alt="superhero" /> : null}</Icon>
               <UserName>{props.name}</UserName>
             </UserInfoWrap>
             {props.isResult ? (
@@ -75,14 +75,21 @@ const Content = styled("div", {
 });
 
 const Icon = styled("div", {
-  square: 35,
-  borderRadius: 9999,
+  width: "3rem",
+  height: "3rem",
+  borderRadius: "9999px",
   background: "$primary9",
+});
+
+const Image = styled("img", {
+  width: "3rem",
+  height: "3rem",
+  borderRadius: "9999px",
 });
 
 const UserName = styled("span", {
   fontWeight: 500,
-  fontSize: "0.9rem",
+  fontSize: "1rem",
   color: "$slate11",
 });
 

--- a/src/components/dnd/Item.tsx
+++ b/src/components/dnd/Item.tsx
@@ -24,9 +24,7 @@ export const Item: VFC<Props> = memo((props) => {
       <p>{resultTrivia.content}</p>
       <UserCard>
         <User>
-          <ImageContainer>
-            <img src={resultTrivia.User.image} width={40} height={40} alt="superhero" />
-          </ImageContainer>
+          <Icon>{resultTrivia.User.image ? <Image src={resultTrivia.User.image} alt="superhero" /> : null}</Icon>
           <Name>{resultTrivia.User.name}</Name>
         </User>
         {resultTrivia.featured ? <div>{resultTrivia.hee}</div> : null}
@@ -55,11 +53,17 @@ const UserCard = styled("div", {
   alignItems: "center",
 });
 
-const ImageContainer = styled("div", {
+const Icon = styled("div", {
   width: "2rem",
   height: "2rem",
   borderRadius: "9999px",
-  display: "flex",
+  backgroundColor: "$primary10",
+});
+
+const Image = styled("img", {
+  width: "2rem",
+  height: "2rem",
+  borderRadius: "9999px",
 });
 
 const User = styled("div", {

--- a/src/pages/broadcast/[broadcastId]/archive/index.page.tsx
+++ b/src/pages/broadcast/[broadcastId]/archive/index.page.tsx
@@ -73,6 +73,7 @@ const ArchivePage: NextPage = () => {
       {Trivia
         ? Trivia.map((item, index) => (
           <EngiviaCard
+            image={item.User.image}
             key={item.id}
             id={item.id}
             content={item.content}

--- a/src/pages/broadcast/[broadcastId]/my_engivia/index.page.tsx
+++ b/src/pages/broadcast/[broadcastId]/my_engivia/index.page.tsx
@@ -48,7 +48,12 @@ const MyEngiviaPage: NextPage = () => {
             </>
           ) : (
             <>
-              <EngiviaCard id={data.id} content={data.Trivia[0].content} name={data.Trivia[0].User.name} />
+              <EngiviaCard
+                id={data.id}
+                image={userInfo.image}
+                content={data.Trivia[0].content}
+                name={data.Trivia[0].User.name}
+              />
               <ButtonWrap>
                 <Button color="primary" onClick={handleEditToggle}>
                   編集する


### PR DESCRIPTION
## 変更内容（必須）

- エンジビアカード上にユーザーアイコンを表示させた
-

## 確認して欲しい項目（必須）

- [ ]全てのページにおいて、ユーザーアイコンが表示されているか
- [ ]

## どうやって確認するのか（必須）

1. 全てのページにおいて、ユーザーアイコンが表示されているか確認する（画像の左側のようなアイコン）
1. （slack認証でログインし、エンジビアを投稿後、各ページにきちんと表示されているか、確認する）
<img width="1674" alt="スクリーンショット 2021-12-09 21 50 29" src="https://user-images.githubusercontent.com/74912714/145400478-63ea5c0f-406b-4460-b1a1-644fb259628d.png">


## 新たな課題

- 画像urlが存在しない場合どう表示させるか 
-

## 備考

-
-
