### PR TITLE
Feature/issue#99

### DIFF
--- a/src/functions/dndValidation.ts
+++ b/src/functions/dndValidation.ts
@@ -24,13 +24,12 @@ export const dndValidation = (broadcast: any, items: any, activeId: any, overId:
   const isOverContainer2 = `${overContainer}` === "container2";
 
   if (isDragEnd) {
-    // ドラッグ終了時、元々あった場所だった場合は動かせない
+    // ドラッグ終了時、元々あった場所だった場合は並び替え処理のみ行う
     const dragEndCheck = activeContainer !== overContainer;
-
     if (dragEndCheck) {
-      return [true, activeContainer, overContainer];
+      return [false, activeContainer, overContainer];
     }
-    return [false, activeContainer, activeContainer];
+    return [true, activeContainer, activeContainer];
   }
 
   // ドラッグオーバー時、元々あった場所だった場合は動かせない
@@ -41,8 +40,8 @@ export const dndValidation = (broadcast: any, items: any, activeId: any, overId:
 
   // container1にあったフィーチャー済みではないものはcontainer2に移動できない
   const check1 = isActiveContainer1 && isOverContainer2 && notFeature;
-  // container2にあったフィーチャー済みではないものはcontainer2に移動できない
-  const check2 = isActiveContainer2 && isOverContainer2 && notFeature;
+  // rootにあったフィーチャー済みではないものはcontainer2に移動できない
+  const check2 = isActiveRoot && isOverContainer2 && notFeature;
   // container2にあったフィーチャー済みのものはcontainer1に移動できない
   const check3 = isActiveContainer2 && isOverContainer1 && isFeature;
   // container2にあったフィーチャー済みのものはrootに移動できない

--- a/src/hooks/useDndTrivia.ts
+++ b/src/hooks/useDndTrivia.ts
@@ -130,6 +130,7 @@ export const useDndTrivia = (props: Props) => {
     const overId = over?.id;
 
     const [result, activeContainer, overContainer] = dndValidation(broadcast, items, activeId, overId, true);
+    if (!result) return;
 
     if (overContainer === "container2") {
       const PutBody = { hee: props.totalHeeCount === 0 ? 0 : props.totalHeeCount };
@@ -150,7 +151,6 @@ export const useDndTrivia = (props: Props) => {
       setIsFeature(false);
     }
 
-    if (!result || activeContainer !== overContainer) return;
     const activeIndex = items[activeContainer].indexOf(activeId);
     const overIndex = items[overContainer].indexOf(Number(overId));
     if (activeIndex !== overIndex) {


### PR DESCRIPTION
## 変更内容（必須）

- トリビアを謝ってフィーチャー済みにドラッグしても、フィーチャー中に戻せるようにした
-

## 確認して欲しい項目（必須）

- [ ] トリビアをフィーチャー済みにdndする際、トリビアをドラッグしただけであればフィーチャー済みに戻すことができる

## どうやって確認するのか（必須）

1. broadcast/[id]/admin/pageにおいて、トリビアを一つタイトルコールする
1. トリビアをフィーチャー済みにdndする際、トリビアをドラッグしただけであればフィーチャー済みに戻すことができることを確認
1. ドロップした後はフィーチャー中に戻せないことを確認


