### PR TITLE
✨ サインアウト、退会機能の実装

### DIFF
--- a/src/hooks/deleteUser.ts
+++ b/src/hooks/deleteUser.ts
@@ -1,0 +1,15 @@
+import { parseCookies } from "nookies";
+import { API_URL } from "src/constants/API_URL";
+import fetch from "unfetch";
+
+export const deleteUser = (url: string) => {
+  // Cookieを読み込む
+  const cookies = parseCookies();
+  return fetch(`${API_URL}${url}`, {
+    method: "DELETE",
+    headers: {
+      // eslint-disable-next-line @typescript-eslint/naming-convention
+      Authorization: `Bearer ${cookies.token}`,
+    },
+  }).then((res) => res.status);
+};

--- a/src/pages/broadcast/index.page.tsx
+++ b/src/pages/broadcast/index.page.tsx
@@ -8,6 +8,7 @@ import { FetcherExample } from "src/components/FetcherExample";
 import { Button, PageRoot, Title } from "src/components/styled";
 import { useGetSWR } from "src/hooks/useGetSWR";
 import { styled } from "src/utils";
+import toast, { Toaster } from "react-hot-toast";
 
 export type LiveStatus = "upcoming" | "live" | "ended";
 
@@ -31,6 +32,7 @@ const BroadcastPage: NextPage = () => {
       {data && <FetcherExample />}
 
       <Title>放送一覧</Title>
+      <Toaster />
 
       {isLoading ? (
         "loading"


### PR DESCRIPTION
## 変更内容

- 右上のアイコンをクリックして、Log Outボタンを押すと、サインイン画面に遷移するようにしました。
- 右上のアイコンをクリックして、Leaveボタンを押すと、DBのユーザー情報とエンジビア情報を削除してサインイン画面に遷移するようにしました。

## 確認して欲しい項目（必須）

- [ ] Log Outボタンを押すとCookieに保存されているトークンが削除され、サインイン画面に遷移するか
- [ ] Leaveボタンを押すとCookieに保存されているトークンが削除され、DBのユーザー情報とエンジビア情報が削除され他のち、サインイン画面に遷移するか
- [ ] 

## どうやって確認するのか（必須）

1. 右上のアイコンをクリックしてLog Outボタンを押してサインイン画面に遷移されるか確認する。
2. テストユーザー2で放送3にエンジビアを投稿してみる。
3. prisma studioを開いて、放送3にエンジビアが投稿されたことを確認する。
4. Leaveボタンを押して、ユーザー情報と先ほど投稿したエンジビアが削除されている確認する。

## 新たな課題

- なし

## 備考

Cookieにトークンが保存されているか確認する方法は、
デベロッパーツールを開いてコンソール、ソースなどの欄からアプリケーションを選択する。
選択すると、デベロッパーツールの左側にアプリケーション、ストレージ、キャッシュの欄が表示される。
ストレージからCookieを選択しCookieの下にある、URLをクリックするとCookieに保存されている情報を見ることができる。

Closes #105 