### PR TITLE
Slack認証後で放送一覧へのリダイレクトができないバグを修正

### DIFF
--- a/src/components/layout/Layout.tsx
+++ b/src/components/layout/Layout.tsx
@@ -11,7 +11,7 @@ type Props = {
 export const Layout: VFC<Props> = (props) => {
   const router = useRouter();
   const notSignin = router.pathname !== "/signin" && router.pathname !== "/signin/oauth_redirect";
-  const notBroadcastList = router.pathname !== "/broadcast";
+  const notBroadcastList = router.pathname !== "/broadcast" && router.pathname !== "/signin/oauth_redirect";
 
   return (
     <Root>

--- a/src/pages/signin/index.page.tsx
+++ b/src/pages/signin/index.page.tsx
@@ -1,11 +1,14 @@
 /* eslint-disable react/jsx-handler-names */
 /* eslint-disable @typescript-eslint/naming-convention */
 import type { NextPage } from "next";
+import Link from "next/link";
+import { parseCookies } from "nookies";
 import { Button } from "src/components/styled";
 import { API_URL } from "src/constants/API_URL";
 import { styled } from "src/utils";
 
 const SigninPage: NextPage = () => {
+  const cookies = parseCookies();
   return (
     <SigninPageRoot>
       <LeftSide>
@@ -13,12 +16,21 @@ const SigninPage: NextPage = () => {
         <Title>エンジビアの泉</Title>
         <SubTitle>〜素晴らしきプログラミングマメ知識〜</SubTitle>
         <Spacer />
-        <a href={`${API_URL}/slack/signin`}>
-          <Button color="white">
-            <img src="/slack-logo.svg" alt="slackのアイコン" width={22} height={22} />
-            Sign in with Slack
-          </Button>
-        </a>
+        {cookies.token ? (
+          <Link href="/broadcast" passHref>
+            <Button color="white">
+              <img src="/slack-logo.svg" alt="slackのアイコン" width={22} height={22} />
+              Sign in with Slack
+            </Button>
+          </Link>
+        ) : (
+          <a href={`${API_URL}/slack/signin`}>
+            <Button color="white">
+              <img src="/slack-logo.svg" alt="slackのアイコン" width={22} height={22} />
+              Sign in with Slack
+            </Button>
+          </a>
+        )}
       </LeftSide>
 
       <RightSide>

--- a/src/pages/signin/oauth_redirect.page.tsx
+++ b/src/pages/signin/oauth_redirect.page.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable react-hooks/rules-of-hooks */
 import type { NextPage } from "next";
 import { useRouter } from "next/router";
-import { parseCookies, setCookie } from "nookies";
+import { setCookie } from "nookies";
 import { PageRoot } from "src/components/styled";
 import { API_URL } from "src/constants/API_URL";
 import { styled } from "src/utils";
@@ -28,8 +28,7 @@ const signinRedirectPage: NextPage = () => {
   const router = useRouter();
   // Slack認証をしてユーザー情報とトークンを取得する
   const { data, error } = useSWR<User>(`${API_URL}/slack/token?code=${router.query.code}`, fetcher);
-  const cookies = parseCookies();
-  if (data && !error && !cookies.token) {
+  if (data && !error) {
     console.info("set Cookie");
     setCookie(null, "token", data.token, {
       // maxAge: 30 * 24 * 60 * 60,


### PR DESCRIPTION
## 変更内容

- Cookieにトークンがあると、認証後の放送一覧へのリダイレクトができないバグを修正した。
- 認証後の画面に戻るボタンが表示されていたため、表示させないようにした。
- Cookieにトークンがある場合、Slack認証をスキップするようにした。

## 確認して欲しい項目

- [ ] Cookieにトークンがある状態で、`Sign in with Slack`ボタンを押すと、放送一覧ページに飛ぶか
- [ ] 認証後の画面に戻るボタンが表示されていないか

## どうやって確認するのか

1. https://87699a39.engivia-frontend.pages.dev/signin にアクセスしてSlack認証を行う。
2. 放送一覧ページに遷移した後、またサインページにアクセスする。
3. `Sign in with Slack`ボタンを押すと、放送一覧ページに遷移する。
