### PR TITLE
✨ プロフィール画像変更機能

### DIFF
--- a/src/components/EngiviaCard.tsx
+++ b/src/components/EngiviaCard.tsx
@@ -22,7 +22,7 @@ export const EngiviaCard: VFC<Props> = (props) => {
           <EngiviaContent>{props.content}</EngiviaContent>
           <Content>
             <UserInfoWrap>
-              <Icon>{props.image ? <Image src={props.image} alt="superhero" /> : null}</Icon>
+              <Icon>{props.image ? <Image src={props.image} alt="userIcon" /> : null}</Icon>
               <UserName>{props.name}</UserName>
             </UserInfoWrap>
             {props.isResult ? (

--- a/src/components/User.tsx
+++ b/src/components/User.tsx
@@ -55,7 +55,7 @@ export const User = () => {
     <Popover>
       <PopoverTrigger asChild>
         <IconButton aria-label="Update dimensions">
-          <Image className="rounded-full" src={userInfo?.image} width={80} height={80} alt="userIcon" />
+          <Image className="rounded-full" src={userInfo.image} alt="userIcon" />
         </IconButton>
       </PopoverTrigger>
       <PopoverContent sideOffset={5}>
@@ -83,6 +83,8 @@ const Main = styled("div", {
 
 const Image = styled("img", {
   borderRadius: "9999px",
+  height: "100%",
+  width:"100%"
 });
 
 const slideUpAndFade = keyframes({

--- a/src/components/User.tsx
+++ b/src/components/User.tsx
@@ -51,6 +51,11 @@ export const User = () => {
     }
   };
 
+  const handleToggleLeaveOpen = () => {
+    setIsLeave(!isleave);
+  };
+
+  const [isleave, setIsLeave] = useState(false);
   return (
     <Popover>
       <PopoverTrigger asChild>
@@ -59,21 +64,63 @@ export const User = () => {
         </IconButton>
       </PopoverTrigger>
       <PopoverContent sideOffset={5}>
-        <Main>
-          <UserInfo />
-        </Main>
-        <Footer>
-          <Button color="smallerSecondary" disabled={buttonDisabledState} onClick={handleSignout}>
-            ログアウト
-          </Button>
-          <Button color="smallerPrimary" disabled={buttonDisabledState} onClick={handleDeleteUser}>
-            退会
-          </Button>
-        </Footer>
+        {isleave ? (
+          <>
+            <Leave>
+              <div>
+                <Announce1>本当に退会しますか？</Announce1>
+                <br />
+                <Announce2>全てのユーザー情報、投稿したエンジビアの内容が削除されます。</Announce2>
+              </div>
+              <Footer>
+                <Button color="secondary" onClick={handleDeleteUser}>
+                  退会
+                </Button>
+                <Button color="primary" onClick={handleToggleLeaveOpen}>
+                  戻る
+                </Button>
+              </Footer>
+            </Leave>
+          </>
+        ) : (
+          <>
+            <Main>
+              <UserInfo />
+            </Main>
+            <Footer>
+              <Button color="smallerPrimary" disabled={buttonDisabledState} onClick={handleSignout}>
+                ログアウト
+              </Button>
+              <Button color="smallerSecondary" disabled={buttonDisabledState} onClick={handleToggleLeaveOpen}>
+                退会
+              </Button>
+            </Footer>
+          </>
+        )}
       </PopoverContent>
     </Popover>
   );
 };
+
+const Leave = styled("div", {
+  display: "flex",
+  flexDirection: "column",
+  gap: "1.25rem",
+  justifyContent: "center",
+  alignItems: "center",
+  height: "100%",
+  textAlign: "center",
+});
+
+const Announce1 = styled("p", {
+  paddingY: "1.25rem",
+  fontSize: "1.25rem",
+  lineHeight: "1.75rem",
+});
+const Announce2 = styled("p", {
+  paddingX: "2.5rem",
+});
+
 const Main = styled("div", {
   height: "75%",
   textAlign: "center",
@@ -84,7 +131,7 @@ const Main = styled("div", {
 const Image = styled("img", {
   borderRadius: "9999px",
   height: "100%",
-  width:"100%"
+  width: "100%",
 });
 
 const slideUpAndFade = keyframes({

--- a/src/components/User.tsx
+++ b/src/components/User.tsx
@@ -22,11 +22,9 @@ export const User = () => {
   const router = useRouter();
   // Cookieを読み込む
   const cookies = parseCookies();
-
   // Cookieに保存されているトークンを使ってユーザー情報を取得する。
-  // 本番では userInfo.id === "user2"(recoilがデフォルト値である場合) を !userInfoにした方がいいかも(atomのデフォ値もnullにしたい)
+  // 本番では userInfo.id === "user2" を !userInfoにした方がいいかも(atomのデフォ値もnullにしたい)
   const { data, error } = useGetSWR<FetchUserInfo>({ url: "/user", shouldFetch: userInfo.id === "user2" });
-
   if (data && !error && userInfo.id === "user2") {
     // recoilにユーザー情報とトークンを保存する。
     setUserInfo({ ...data, token: cookies.token });
@@ -46,7 +44,7 @@ export const User = () => {
       toast.error(`error: ${statusCode}`, { id: toastId });
       setButtonDisabledState(false);
     } else {
-      toast.success("削除成功しました", { id: toastId });
+      toast.success("退会しました", { id: toastId });
       destroyCookie(null, "token", { path: "/" });
       // トーストを表示した2秒後にページ遷移する
       setTimeout(() => router.push("/signin"), 2000);
@@ -62,7 +60,7 @@ export const User = () => {
       </PopoverTrigger>
       <PopoverContent sideOffset={5}>
         <Main>
-          <UserInfo user={userInfo} />
+          <UserInfo />
         </Main>
         <Footer>
           <Button color="smallerSecondary" disabled={buttonDisabledState} onClick={handleSignout}>

--- a/src/components/UserInfo.tsx
+++ b/src/components/UserInfo.tsx
@@ -1,23 +1,14 @@
 import { violet } from "@radix-ui/colors";
 import { useRouter } from "next/router";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback } from "react";
 import { useRecoilValue } from "recoil";
 import { userInfoState } from "src/components/atoms";
 import { Button } from "src/components/styled";
 import { styled } from "src/utils";
 
-type Props = {
-  user: any;
-};
-
-export const UserInfo = (props: Props) => {
+export const UserInfo = () => {
   const userInfo = useRecoilValue(userInfoState);
-  const [name, setName] = useState("");
   const router = useRouter();
-
-  useEffect(() => {
-    setName(userInfo.name);
-  }, [userInfo.name]);
 
   const handleToggleEdit = useCallback(() => {
     router.push("/profileEdit");
@@ -32,9 +23,9 @@ export const UserInfo = (props: Props) => {
       </EditArea>
 
       <Person>
-        <Image className="rounded-full" src={props.user.image} alt="userIcon" />
+        <Image className="rounded-full" src={userInfo.image} alt="userIcon" />
         <NameArea>
-          <Nombre>{name}</Nombre>
+          <Nombre>{userInfo.name}</Nombre>
         </NameArea>
       </Person>
     </>

--- a/src/components/inputFile.tsx
+++ b/src/components/inputFile.tsx
@@ -29,13 +29,27 @@ export const InputFile = (props: Props) => {
 
   return (
     <div>
-      <input type="file" name={props.name} id="" src={props.value} onChange={handleChangeInputFile} />
+      <Label>
+        画像を選択
+        <Input type="file" name={props.name} src={props.value} onChange={handleChangeInputFile} />
+      </Label>
       <div>
         <Image src={props.value} alt="プロフィール画像" />
       </div>
     </div>
   );
 };
+
+const Label = styled("label", {
+  padding: "10px",
+  borderRadius: "9999px",
+  backgroundColor: "$white",
+  border: "1px solid $slate8",
+  "&:hover": { backgroundColor: "$slate5" },
+});
+const Input = styled("input", {
+  display: "none",
+});
 
 const Image = styled("img", {
   height: "300px",

--- a/src/components/inputFile.tsx
+++ b/src/components/inputFile.tsx
@@ -1,0 +1,44 @@
+import { styled } from "@stitches/react";
+import { useEffect } from "react";
+import { DefaultValue } from "recoil";
+
+type Props = {
+  name: string;
+  defaultValue?: any;
+  value: any;
+  setValue: any;
+};
+
+export const InputFile = (props: Props) => {
+  useEffect(() => {
+    if (DefaultValue) {
+      props.setValue(props.defaultValue);
+    }
+  }, [props, props.defaultValue]);
+
+  const handleChangeInputFile = (e: any) => {
+    if (e.target.files && e.target.files[0]) {
+      const file = e.target.files[0];
+      const reader = new FileReader();
+      reader.onload = (e: any) => {
+        props.setValue(e.target.result);
+      };
+      reader.readAsDataURL(file);
+    }
+  };
+
+  return (
+    <div>
+      <input type="file" name={props.name} id="" src={props.value} onChange={handleChangeInputFile} />
+      <div>
+        <Image src={props.value} alt="プロフィール画像" />
+      </div>
+    </div>
+  );
+};
+
+const Image = styled("img", {
+  height: "300px",
+  width: "300px",
+  borderRadius: "9999px",
+});

--- a/src/pages/profileEdit.page.tsx
+++ b/src/pages/profileEdit.page.tsx
@@ -28,6 +28,11 @@ const ProfileEditPage = () => {
   // イメージデータを変換する
   const handleToBase64Url = (url: string, callback: any) => {
     setButtonDisabledState(true);
+    if (text === userInfo.name || image === userInfo.image) {
+      toast.error("変更点がありません");
+      setButtonDisabledState(false);
+      return;
+    }
     const xhr = new XMLHttpRequest();
     xhr.onload = function () {
       const reader = new FileReader();
@@ -45,6 +50,17 @@ const ProfileEditPage = () => {
 
   // ユーザー情報を更新する
   const handleSendUrl = async (xhr: string) => {
+    if (!text || !/\S/g.test(text)) {
+      toast.error("名前を入力してください");
+      setButtonDisabledState(false);
+      return;
+    }
+    if (!image) {
+      toast.error("画像を選択してください");
+      setButtonDisabledState(false);
+      return;
+    }
+
     const body = {
       name: text,
       base64Image: xhr,

--- a/src/pages/profileEdit.page.tsx
+++ b/src/pages/profileEdit.page.tsx
@@ -28,7 +28,7 @@ const ProfileEditPage = () => {
   // イメージデータを変換する
   const handleToBase64Url = (url: string, callback: any) => {
     setButtonDisabledState(true);
-    if (text === userInfo.name || image === userInfo.image) {
+    if (text === userInfo.name && image === userInfo.image) {
       toast.error("変更点がありません");
       setButtonDisabledState(false);
       return;
@@ -63,7 +63,7 @@ const ProfileEditPage = () => {
 
     const body = {
       name: text,
-      base64Image: xhr,
+      base64Image: xhr.replace(/data:image\/png;base64,|data:image\/jpeg;base64,/, ""),
     };
     const codeState = await requestFetcher("/user", body, "PUT", userInfo.token);
     if (codeState >= 400) {

--- a/src/pages/profileEdit.page.tsx
+++ b/src/pages/profileEdit.page.tsx
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import toast, { Toaster } from "react-hot-toast";
 import { useRecoilState } from "recoil";
 import { userInfoState } from "src/components/atoms";
+import { InputFile } from "src/components/inputFile";
 import { Button, Input, PageRoot, Title } from "src/components/styled";
 import { requestFetcher } from "src/functions/requestFetcher";
 import { styled } from "src/utils";
@@ -10,28 +11,57 @@ import { styled } from "src/utils";
 const ProfileEditPage = () => {
   const [userInfo, setUserInfo] = useRecoilState(userInfoState);
   const [text, setText] = useState("");
+  const [image, setImage] = useState("");
+  const [buttonDisabledState, setButtonDisabledState] = useState(false);
 
   useEffect(() => {
     if (userInfo) {
       setText(userInfo.name);
+      setImage(userInfo.image);
     }
   }, [userInfo]);
 
-  const handleSaveUserName = async () => {
-    const body = {
-      name: text,
-    };
-    const statusCode = await requestFetcher("/user", body, "PUT", userInfo.token);
-    if (statusCode >= 400) {
-      toast.error("保存に失敗しました");
-      return;
-    }
-    setUserInfo({ ...userInfo, name: text });
-    toast.success("保存しました");
-  };
-
   const handleText = (e: any) => {
     setText(e.target.value);
+  };
+
+  // イメージデータを変換する
+  const handleToBase64Url = (url: string, callback: any) => {
+    setButtonDisabledState(true);
+    const xhr = new XMLHttpRequest();
+    xhr.onload = function () {
+      const reader = new FileReader();
+      reader.onloadend = function () {
+        callback(reader.result);
+      };
+      reader.readAsDataURL(xhr.response);
+    };
+    xhr.open("GET", url);
+    xhr.responseType = "blob";
+    xhr.send();
+
+    return xhr.responseURL;
+  };
+
+  // ユーザー情報を更新する
+  const handleSendUrl = async (xhr: string) => {
+    const body = {
+      name: text,
+      base64Image: xhr,
+    };
+    const codeState = await requestFetcher("/user", body, "PUT", userInfo.token);
+    if (codeState >= 400) {
+      toast.error("保存できませんでした");
+      setButtonDisabledState(false);
+      return;
+    }
+    setUserInfo({
+      ...userInfo,
+      name: text,
+      image: `${xhr}`,
+    });
+    setButtonDisabledState(false);
+    toast.success("保存しました");
   };
 
   return (
@@ -40,10 +70,14 @@ const ProfileEditPage = () => {
         <Root>
           <Title>プロフィールを編集する</Title>
         </Root>
-
-        <Image className="rounded-full" src={userInfo?.image} alt="userIcon" />
+        <InputFile name="プロフィール画像" defaultValue={image} value={image} setValue={setImage} />
         <Input width="small" type="text" value={text} onChange={handleText} />
-        <Button color="primary" onClick={handleSaveUserName}>
+        {/* eslint-disable-next-line react/jsx-handler-names */}
+        <Button
+          color="primary"
+          disabled={buttonDisabledState}
+          onClick={() => handleToBase64Url(image, (xhr: string) => handleSendUrl(xhr))}
+        >
           保存
         </Button>
         <Toaster />
@@ -51,13 +85,6 @@ const ProfileEditPage = () => {
     </>
   );
 };
-
-const Image = styled("img", {
-  width: "300px",
-  height: "300px",
-  marginY: "20px",
-  borderRadius: "9999px",
-});
 
 const Root = styled("div", {
   display: "flex",


### PR DESCRIPTION
## 変更内容（必須）

- プロフィールの画像を変更できるようにした
- (追加）退会時に確認画面を表示させるようにした

## 確認して欲しい項目（必須）

- [ ] プロフィール画像が変更できるか
- [ ] 退会ボタンを押した際に確認画面が表示されるか

## どうやって確認するのか（必須）

1. ヘッダー右上アイコンから編集ボタンをクリック
1. 編集ページに飛ぶので、画像と名前を変更し、保存をクリック
1. 画像と名前が変更されることを確認
1. 退会ボタンを押す→確認画面が出てくるので、退会ボタン、戻るボタンをそれぞれクリックし、機能しているか確認する

## 新たな課題

- アイコンが一度しか変更できない
- 見た目

## 備考

-
-
